### PR TITLE
備品削除機能の作成

### DIFF
--- a/FixtureManagementApp/ContentView.swift
+++ b/FixtureManagementApp/ContentView.swift
@@ -91,7 +91,8 @@ struct FixtureList: View {
                 }
             }.onDelete(perform: { indexSet in
                 // 備品削除
-                // DbManager().deleteFixture(id: 1)
+                DbManager().deleteFixture(id: self.fixturesList[indexSet.first!].id)
+                self.fixturesList.remove(atOffsets: indexSet)
             })
         }
         .listStyle(PlainListStyle())


### PR DESCRIPTION
一覧ページで各備品を削除できるようにする
リストを左にスワイプしてから「Delete」ボタンを押すと対象の備品が削除できる