### PR TITLE
カメラ起動&ライブラリー選択機能の作成

### DIFF
--- a/FixtureManagementApp/AddFixtureView.swift
+++ b/FixtureManagementApp/AddFixtureView.swift
@@ -41,6 +41,7 @@ struct AddFixtureView: View {
             HStack {
                 NewImageRow()
             }
+            .padding(.horizontal)
             
             ZStack {
                 CategoryPicker(selection: self.$categoryPickerId, isShowing: self.$isShowingCategoryPicker, cateroryMessage: self.$newCategoryMessage)
@@ -180,17 +181,42 @@ struct NewFixtureQuantityRow: View {
 }
 // 画像行
 struct NewImageRow: View {
+    @State private var image: UIImage?
+    @State private var showCameraView = false
+    @State private var sourceType: UIImagePickerController.SourceType = .camera
     var body: some View {
-        // 画像(文字)
-        Text("画像")
-            .padding(.horizontal)
-        // カメラを起動するボタン
-        Button(action: {
-            print("カメラ起動")
-        }) {
-            Text("+")
-                .foregroundColor(Color.blue)
+        HStack {
+            Text("画像")
+            if image != nil {
+                Image(uiImage: image!)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
+            } else {
+                Menu {
+                    Button(action: {
+                        self.sourceType = .camera
+                        self.showCameraView.toggle()
+                    }, label: {
+                        Text("カメラを起動")
+                    })
+                    .padding()
+                    
+                    Button(action: {
+                        self.sourceType = .photoLibrary
+                        self.showCameraView.toggle()
+                    }, label: {
+                        Text("ライブラリから画像を選択")
+                    })
+                } label: {
+                    Text("+")
+                }
+                .padding()
+            }
         }
+        .sheet(isPresented: self.$showCameraView, content: {
+            SwiftUIImagePicker(image: self.$image, showCameraView: self.$showCameraView, sourceType: self.$sourceType)
+        })
         Spacer()
     }
 }

--- a/FixtureManagementApp/Common.swift
+++ b/FixtureManagementApp/Common.swift
@@ -157,3 +157,52 @@ struct UnitModalView: View {
         }
     }
 }
+
+// カメラ、ライブラリー機能
+struct SwiftUIImagePicker: UIViewControllerRepresentable {
+    // 画像保存
+    @Binding var image: UIImage?
+    // カメラorライブラリー表示フラグ
+    @Binding var showCameraView: Bool
+    // カメラorライブラリーの選択肢
+    @Binding var sourceType: UIImagePickerController.SourceType
+    
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(self)
+    }
+    
+    // カメラorライブラリーのビュー作成
+    func makeUIViewController(context: Context) -> some UIViewController {
+        let viewController = UIImagePickerController()
+        viewController.delegate = context.coordinator
+        if UIImagePickerController.isSourceTypeAvailable(self.sourceType) {
+            viewController.sourceType = self.sourceType
+        }
+        return viewController
+    }
+    
+    // カメラorライブラリーの表示を検知
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+        print("updateUIViewController is called")
+    }
+    
+    // UIImagePickerControllerDelegate:画像関連処理のライブラリー
+    // UINavigationControllerDelegate:ナビゲーションのライブラリー
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let parent: SwiftUIImagePicker
+        init(_ parent: SwiftUIImagePicker) {
+            self.parent = parent
+        }
+        
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let uiImage = info[.originalImage] as? UIImage {
+                self.parent.image = uiImage
+            }
+            self.parent.showCameraView = false
+        }
+        
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            self.parent.showCameraView = false
+        }
+    }
+}

--- a/FixtureManagementApp/EditFixtureView.swift
+++ b/FixtureManagementApp/EditFixtureView.swift
@@ -43,6 +43,7 @@ struct EditFixtureView: View {
             HStack {
                 EditImageRow()
             }
+            .padding(.horizontal)
             
             ZStack {
                 CategoryPicker(selection: self.$categoryPickerId, isShowing: self.$isShowingCategoryPicker, cateroryMessage: self.$newCategoryMessage)
@@ -195,17 +196,42 @@ struct EditFixtureQuantityRow: View {
 }
 // 画像行
 struct EditImageRow: View {
+    @State private var image: UIImage?
+    @State private var showCameraView = false
+    @State private var sourceType: UIImagePickerController.SourceType = .camera
     var body: some View {
-        // 画像(文字)
-        Text("画像")
-            .padding(.horizontal)
-        // カメラを起動するボタン
-        Button(action: {
-            print("カメラ起動")
-        }) {
-            Text("+")
-                .foregroundColor(Color.blue)
+        HStack {
+            Text("画像")
+            if image != nil {
+                Image(uiImage: image!)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
+            } else {
+                Menu {
+                    Button(action: {
+                        self.sourceType = .camera
+                        self.showCameraView.toggle()
+                    }, label: {
+                        Text("カメラを起動")
+                    })
+                    .padding()
+                    
+                    Button(action: {
+                        self.sourceType = .photoLibrary
+                        self.showCameraView.toggle()
+                    }, label: {
+                        Text("ライブラリから画像を選択")
+                    })
+                } label: {
+                    Text("+")
+                }
+                .padding()
+            }
         }
+        .sheet(isPresented: self.$showCameraView, content: {
+            SwiftUIImagePicker(image: self.$image, showCameraView: self.$showCameraView, sourceType: self.$sourceType)
+        })
         Spacer()
     }
 }

--- a/FixtureManagementApp/Info.plist
+++ b/FixtureManagementApp/Info.plist
@@ -46,5 +46,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
画像の横にある「+」を押すと、カメラ起動orライブラリーのメニューが表示される
カメラ起動を選択するとカメラが起動
ライブラリーを選択すると端末内の画像を選択できる
撮影or選択した写真は画面上に表示される

シミュレーター上ではカメラは起動しない